### PR TITLE
Update Github link to the actual Lexend font

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ See <https://github.com/ThomasJockin/readexpro>
 ##  Where To Get It
 
 * Via the website's [download form](https://www.lexend.com/#download)
-* Directly from [GitHub](https://github.com/ThomasJockin/lexend/tree/master/fonts)
+* Directly from [GitHub](https://github.com/googlefonts/lexend/tree/main/fonts)
 * From [CTAN](https://www.ctan.org/pkg/lexend): `tlmgr install lexend`
 * From [Homebrew](https://brew.sh/): `brew cask install font-lexend-deca`
 


### PR DESCRIPTION
The link towards thomasJockin repro is rebrand or new font.

- So I made the switch to point to the Lexend repo for the font.
- Added a link to download from Google Fonts.
- Switch the Github link to the actual Lexend font and not the Readrex Pro font.

Was causing some confusion as it seems like a rebrand on work not related to Lexend.